### PR TITLE
Updated for 3.2.3.  Including unmerged changes from 3.2.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 3.2.3 (2019-12-10)
+
+- Fixed sidebar to allow external url for heading. [#64](https://github.com/blackbaud/skyux-lib-stache/pull/64)
+
+# 3.2.2 (2019-12-04)
+
+- Fixed the action buttons component to support asynchronous route assignments. [#62](https://github.com/blackbaud/skyux-lib-stache/pull/62)
+
 # 3.2.1 (2019-11-25)
 
 - Reverted font changes. [#60](https://github.com/blackbaud/skyux-lib-stache/pull/60)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-lib-stache",
-  "version": "3.2.1",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-lib-stache",
-  "version": "3.2.1",
+  "version": "3.2.3",
   "description": "Angular components for SKY UX Builder SPAs",
   "author": "Blackbaud, Inc.",
   "keywords": [],


### PR DESCRIPTION
It appears [we released 3.2.2](https://www.npmjs.com/package/@blackbaud/skyux-lib-stache), but never updated master with [these changes](https://github.com/blackbaud/skyux-lib-stache/compare/release-3.2.2).  I'm guessing we accidentally released from that branch (instead of master).

Including those changes here to release 3.2.3.