### PR TITLE
[rc] Update InputConverter to check types explicitly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -361,9 +361,9 @@
       }
     },
     "@blackbaud/skyux-lib-code-block": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-lib-code-block/-/skyux-lib-code-block-2.0.0-rc.0.tgz",
-      "integrity": "sha512-hFDOkRSpiISB0T53KsVgZgDjw2r7b3z0IZEerDEtiiyuUY9kyrKROvKySIEtdyLfpQXDm4YbdRl5TyVVRcMgdw==",
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-lib-code-block/-/skyux-lib-code-block-2.0.0-rc.1.tgz",
+      "integrity": "sha512-dKOSz14o9DXWqs1TXCvH+FINnIo3Beq7spE4JrV3GcVCD7qqbGtuzE1P/G9qo2IKkSKkT7f9fzibjuDLsAySmQ==",
       "dev": true,
       "requires": {
         "prismjs": "1.19.0"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@blackbaud/skyux-builder-plugin-code-block": "1.1.0",
     "@blackbaud/skyux-builder-plugin-stache": "2.0.1",
     "@blackbaud/skyux-lib-clipboard": "2.0.0-rc.0",
-    "@blackbaud/skyux-lib-code-block": "2.0.0-rc.0",
+    "@blackbaud/skyux-lib-code-block": "2.0.0-rc.1",
     "@blackbaud/skyux-lib-media": "2.0.0-rc.0",
     "@blackbaud/skyux-lib-restricted-view": "2.0.0-rc.0",
     "@pact-foundation/pact-web": "9.7.0",

--- a/src/app/public/modules/action-buttons/action-buttons.component.ts
+++ b/src/app/public/modules/action-buttons/action-buttons.component.ts
@@ -1,7 +1,11 @@
 import { Component, Input, OnInit } from '@angular/core';
 
 import { StacheNavLink } from '../nav/nav-link';
-import { InputConverter } from '../shared/input-converter';
+
+import {
+  booleanConverter,
+  InputConverter
+} from '../shared/input-converter';
 
 @Component({
   selector: 'stache-action-buttons',
@@ -20,7 +24,7 @@ export class StacheActionButtonsComponent implements OnInit {
   }
 
   @Input()
-  @InputConverter()
+  @InputConverter(booleanConverter)
   public showSearch: boolean = true;
 
   public filteredRoutes: StacheNavLink[];

--- a/src/app/public/modules/back-to-top/back-to-top.component.ts
+++ b/src/app/public/modules/back-to-top/back-to-top.component.ts
@@ -5,7 +5,8 @@ import {
 } from '@angular/core';
 
 import {
-  InputConverter
+  InputConverter,
+  numberConverter
 } from '../shared/input-converter';
 
 import {
@@ -19,7 +20,7 @@ import {
 })
 export class StacheBackToTopComponent {
   @Input()
-  @InputConverter()
+  @InputConverter(numberConverter)
   public offset: number = 200;
 
   public isHidden: boolean = true;

--- a/src/app/public/modules/layout/layout-container.component.ts
+++ b/src/app/public/modules/layout/layout-container.component.ts
@@ -8,6 +8,7 @@ import {
 } from './layout';
 
 import {
+  booleanConverter,
   InputConverter
 } from '../shared/input-converter';
 
@@ -30,18 +31,18 @@ export class StacheLayoutContainerComponent implements StacheLayout {
   public inPageRoutes: StacheNavLink[];
 
   @Input()
-  @InputConverter()
+  @InputConverter(booleanConverter)
   public showBackToTop: boolean;
 
   @Input()
-  @InputConverter()
+  @InputConverter(booleanConverter)
   public showBreadcrumbs: boolean;
 
   @Input()
-  @InputConverter()
+  @InputConverter(booleanConverter)
   public showEditButton: boolean;
 
   @Input()
-  @InputConverter()
+  @InputConverter(booleanConverter)
   public showTableOfContents: boolean;
 }

--- a/src/app/public/modules/layout/layout-sidebar.component.ts
+++ b/src/app/public/modules/layout/layout-sidebar.component.ts
@@ -8,6 +8,7 @@ import {
 } from './layout';
 
 import {
+  booleanConverter,
   InputConverter
 } from '../shared/input-converter';
 
@@ -33,18 +34,18 @@ export class StacheLayoutSidebarComponent implements StacheLayout {
   public sidebarRoutes: StacheNavLink[];
 
   @Input()
-  @InputConverter()
+  @InputConverter(booleanConverter)
   public showBackToTop: boolean;
 
   @Input()
-  @InputConverter()
+  @InputConverter(booleanConverter)
   public showBreadcrumbs: boolean;
 
   @Input()
-  @InputConverter()
+  @InputConverter(booleanConverter)
   public showEditButton: boolean;
 
   @Input()
-  @InputConverter()
+  @InputConverter(booleanConverter)
   public showTableOfContents: boolean;
 }

--- a/src/app/public/modules/shared/input-converter.spec.ts
+++ b/src/app/public/modules/shared/input-converter.spec.ts
@@ -5,17 +5,6 @@ import {
   numberConverter
 } from './input-converter';
 
-class MockComponent {
-  @InputConverter()
-  public myBoolean: boolean;
-
-  @InputConverter()
-  public myString: string;
-
-  @InputConverter()
-  public myNumber: number;
-}
-
 class MockComponentExplicit {
   @InputConverter(booleanConverter)
   public myBoolean: boolean;
@@ -45,57 +34,5 @@ describe('InputConverter', () => {
 
     component.myNumber = '7' as any;
     expect(component.myNumber).toBe(7);
-  });
-
-  it('should convert values using metadata', () => {
-    const component = new MockComponent();
-
-    component.myBoolean = 'true' as any;
-    expect(component.myBoolean).toBe(true);
-
-    component.myBoolean = 'false' as any;
-    expect(component.myBoolean).toBe(false);
-
-    component.myString = 5 as any;
-    expect(component.myString).toBe('5');
-
-    component.myString = 'hello' as any;
-    expect(component.myString).toBe('hello');
-
-    component.myNumber = '7' as any;
-    expect(component.myNumber).toBe(7);
-  });
-
-  it('should throw an error if the converter does not exist', () => {
-    let component;
-    try {
-      class BadMockComponent {
-        @InputConverter()
-        public myArray: number[];
-      }
-      component = new BadMockComponent();
-
-      // Necessary to keep TS happy
-      component.myArray = [];
-    } catch (error) {
-      expect(error.message).toBe('There is no converter for the given property type Array.');
-    }
-  });
-
-  it('should throw an error if metadata cannot be found', () => {
-    spyOn(Reflect, 'getMetadata').and.returnValue(undefined);
-    let component;
-    try {
-      class BadMockComponent {
-        @InputConverter()
-        public myNumber: number;
-      }
-      component = new BadMockComponent();
-
-      // Necessary to keep TS happy
-      component.myNumber = 0;
-    } catch (error) {
-      expect(error.message).toBe('The reflection metadata could not be found.');
-    }
   });
 });

--- a/src/app/public/modules/shared/input-converter.ts
+++ b/src/app/public/modules/shared/input-converter.ts
@@ -1,9 +1,3 @@
-import {} from 'reflect-metadata';
-
-// Inspiration for this script was taken from:
-// https://blog.rsuter.com/
-//  angular-2-typescript-property-decorator-that-converts-input-values-to-the-correct-type/
-
 export const stringConverter = (value: any) => {
   if (value === undefined || typeof value === 'string') {
     return value;
@@ -28,30 +22,8 @@ export const numberConverter = (value: any) => {
   return parseFloat(value.toString());
 };
 
-const getMetaData = (target: Object, key: string) => {
-  return Reflect.getMetadata('design:type', target, key);
-};
-
-export function InputConverter(converter?: (value: any) => any) {
-  return (target: Object, key: string) => {
-    if (converter === undefined) {
-      let metadata = getMetaData(target, key);
-
-      if (!metadata) {
-        throw new Error('The reflection metadata could not be found.');
-      }
-
-      if (metadata.name === 'String') {
-        converter = stringConverter;
-      } else if (metadata.name === 'Boolean') {
-        converter = booleanConverter;
-      } else if (metadata.name === 'Number') {
-        converter = numberConverter;
-      } else {
-        throw new Error(`There is no converter for the given property type ${metadata.name}.`);
-      }
-    }
-
+export function InputConverter(converter: (value: any) => any) {
+  return (target: any, key: string) => {
     Object.defineProperty(target, key, {
       get: function () {
         return this['__' + key];

--- a/src/app/public/modules/tutorial-step/tutorial-step.component.ts
+++ b/src/app/public/modules/tutorial-step/tutorial-step.component.ts
@@ -4,6 +4,7 @@ import {
 } from '@angular/core';
 
 import {
+  booleanConverter,
   InputConverter
 } from '../shared/input-converter';
 
@@ -14,6 +15,6 @@ import {
 })
 export class StacheTutorialStepComponent {
   @Input()
-  @InputConverter()
+  @InputConverter(booleanConverter)
   public showNumber: boolean = true;
 }

--- a/src/app/public/modules/wrapper/wrapper.component.ts
+++ b/src/app/public/modules/wrapper/wrapper.component.ts
@@ -53,6 +53,7 @@ import {
 } from '../page-anchor/page-anchor.service';
 
 import {
+  booleanConverter,
   InputConverter
 } from '../shared/input-converter';
 
@@ -89,7 +90,7 @@ export class StacheWrapperComponent implements OnInit, AfterViewInit, OnDestroy 
   public showEditButton: boolean = this.checkEditButtonUrl();
 
   @Input()
-  @InputConverter()
+  @InputConverter(booleanConverter)
   public showFooter: boolean = this.checkFooterData();
 
   @Input()


### PR DESCRIPTION
Angular's Ivy compiler strips out `Reflect` metadata, so automatically detecting an `Input`'s type won't be possible in AoT builds anymore. To get around this, all we need to do is tell the `InputConverter` which type conversion to use explicitly.
See: https://github.com/rangle/augury/issues/1335#issuecomment-415772216