### PR TITLE
[HOLD] Bugfix for showing children under similar parent

### DIFF
--- a/src/app/public/modules/router/route.service.spec.ts
+++ b/src/app/public/modules/router/route.service.spec.ts
@@ -95,6 +95,24 @@ class MockStacheConfigService {
       },
       {
         routePath: 'other-parent/other-child/other-grandchild'
+      },
+      {
+        routePath: 'testing-children'
+      },
+      {
+        routePath: 'testing-children/child'
+      },
+      {
+        routePath: 'testing-children1'
+      },
+      {
+        routePath: 'testing-children1/child'
+      },
+      {
+        routePath: 'testing-children2'
+      },
+      {
+        routePath: 'testing-children2/child'
       }
     ]
   };
@@ -203,6 +221,12 @@ describe('StacheRouteService', () => {
       configService as SkyAppConfig,
       routeMetadataService as StacheRouteMetadataService
     );
+  });
+
+  it('should not include child routes from similar parents (a, a1, a2)', () => {
+    router.url = '/testing-children';
+    let activeRoutes = routeService.getActiveRoutes();
+    expect(activeRoutes[0].children.length).toBe(1);
   });
 
   it('should only assemble the active routes once', () => {

--- a/src/app/public/modules/router/route.service.ts
+++ b/src/app/public/modules/router/route.service.ts
@@ -86,7 +86,10 @@ export class StacheRouteService {
 
     routes.forEach(route => {
       const routeDepth = route.segments.length;
-      const isChildRoute = (depth === routeDepth && route.path.indexOf(parentPath) > -1);
+
+      // Adding trailing slash to force end of parent path.  Otherwise:
+      // a/child, a1/child, and a2/child would have all three children displayed under a.
+      const isChildRoute = (depth === routeDepth && route.path.indexOf(parentPath + '/') > -1);
 
       if (isChildRoute) {
         route.children = this.assignChildren(routes, route.path);


### PR DESCRIPTION
It's possible to create a navigation structure which will pull in incorrect children if those children's parent is contained in the current parent.  For example, in the following screenshot `A1Child` and `A2Child` should not be showing up under the `A` parent.

<img width="544" alt="Screen Shot 2020-07-22 at 12 43 00 PM" src="https://user-images.githubusercontent.com/4612419/88208519-57f5cb00-cc1f-11ea-8c7a-0e2919ca682c.png">
